### PR TITLE
Update Infiniti G35 generations: Verified V35 generation data from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Infiniti G35
 
+This repository contains signal set configurations for the Infiniti G35, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Infiniti G35.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Infiniti_G35"
+
 generations:
   - name: "First Generation (V35) Coupe"
     start_year: 2003


### PR DESCRIPTION
- Confirmed V35 Coupe production years: 2003-2007
- Confirmed V35 Sedan production years: 2003-2006
- Verified FM platform and VQ35DE engine specifications
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template
